### PR TITLE
Fix an exception caused by `null` being passed to getPlaceholderStyles

### DIFF
--- a/src/helpers/PowerPackHelpers.php
+++ b/src/helpers/PowerPackHelpers.php
@@ -170,8 +170,10 @@ class PowerPackHelpers
         return false;
     }
 
-    public static function getPlaceholderStyles(TransformedImageInterface $image, Settings $settings): array
+    public static function getPlaceholderStyles(TransformedImageInterface|null $image, Settings $settings): array
     {
+        if (empty($image)) return [];
+
         $placeHolderWidth = $settings->placeholderSize;
         $placeHolderHeight = round($placeHolderWidth * ($image->height / $image->width));
 


### PR DESCRIPTION
Does as the title says.

Somehow, this line:
https://github.com/spacecatninja/craft-imager-x-power-pack/blob/770b949bb0a21d686e143d276ce4b523eaed525d/src/services/PowerPackService.php#L185

can be `null`, despite the image existing within Craft. Fixing this bug also makes the image display as if nothing happened.
